### PR TITLE
Added FoE_SxBuildings table

### DIFF
--- a/Step001_CreateDB.sql
+++ b/Step001_CreateDB.sql
@@ -242,3 +242,144 @@ INSERT INTO FoE_ddSelfDoc (ddToken, ddText, dbStatusID) VALUES ('CxCF_CoinsPerSQ
 INSERT INTO FoE_ddSelfDoc (ddToken, ddText, dbStatusID) VALUES ('CxCF_SecondsPerCoinPerPop','Calculated Field (CF) as CxCF_SecondsPerCoinPerPop = (CxYieldCycle /(CxPopCount / CxCoinYield))', 0);
 INSERT INTO FoE_ddSelfDoc (ddToken, ddText, dbStatusID) VALUES ('CxCF_SecondsPerCoinPerSQR','Calculated Field (CF) as CxCF_SecondsPerCoinPerSQR = ((CxYieldCycle / CxCoinYield) / (CxSWPixels*CxNWPixels)) ', 0);
 -- END of documenting the database
+--
+-- Creating the Supply Buildings table
+CREATE TABLE FoE_SxBuildings ( 
+  aaPK INTEGER PRIMARY KEY AUTOINCREMENT
+, SxID INTEGER (8) NOT NULL
+, SxName VARCHAR (64) NOT NULL
+, SxAge VARCHAR (32) NOT NULL
+, SxTech VARCHAR (32) NOT NULL
+, SxPopRequired INTEGER (4) NOT NULL
+, SxSupplyYieldFiveMinutes_AA INTEGER (4) NOT NULL
+, SxSupplyYieldFifteenMinutes_BB INTEGER (4) NOT NULL
+, SxSupplyYieldOneHour_CC INTEGER (4) NOT NULL
+, SxSupplyYieldFourHours_DD INTEGER (4) NOT NULL
+, SxSupplyYieldEightHours_EE INTEGER (4) NOT NULL
+, SxSupplyYieldOneDay_FF INTEGER (4) NOT NULL
+, SxSupplyYieldTwoDays_GG INTEGER (4) NOT NULL
+, SxSWPixels INTEGER (2) NOT NULL
+, SxNWPixels INTEGER (2) NOT NULL
+, SxRoadWidth INTEGER (2) NOT NULL
+, SxBuildTime INTEGER (4) NOT NULL
+, SxBuildDiamonds INTEGER (4) NOT NULL
+, SxBuildCoins INTEGER (4) NOT NULL
+, SxBuildSupplies INTEGER (4) NOT NULL
+, SxSellCoins INTEGER (4) DEFAULT 0
+, SxSellSupplies INTEGER (4) DEFAULT 0
+, SxCF_AA_Rate_BB REAL (4, 2) DEFAULT 0.00
+, SxCF_AA_Rate_CC REAL (4, 2) DEFAULT 0.00
+, SxCF_AA_Rate_DD REAL (4, 2) DEFAULT 0.00
+, SxCF_AA_Rate_EE REAL (4, 2) DEFAULT 0.00
+, SxCF_AA_Rate_FF REAL (4, 2) DEFAULT 0.00
+, SxCF_AA_Rate_GG REAL (4, 2) DEFAULT 0.00
+, SxCF_AA_Per_Pop REAL (4, 2) DEFAULT 0.00
+, SxCF_AA_Per_SQR REAL (4, 2) DEFAULT 0.00
+, dbStatusID INTEGER (4) 
+, aaTimeStamp DEFAULT CURRENT_TIMESTAMP);
+INSERT INTO FoE_aaAuditor (
+  aaToken
+, aaTable
+, aaROWID
+, aaSQLText
+, aaUUID
+, dbStatusID) 
+VALUES(
+  'CREATE'
+, 'FoE_SxBuildings'
+, 0
+, ''
+, '96d6b400-e237-11e5-bef5-0002a5d5c51b'
+, 0);
+-- END of creating the Supply Buildings table
+--
+-- Creating the AFTER INSERT Trigger
+CREATE TRIGGER "tgINSERT-AFTER_FoE_SxBuildings" AFTER INSERT ON FoE_SxBuildings FOR EACH ROW BEGIN 
+-- Task One Update Audit
+INSERT INTO FoE_aaAuditor (aaToken, aaTable, aaROWID, aaUUID, dbStatusID)
+VALUES ('INSERT', 'FoE_SxBuildings', last_insert_rowid(), '96d6b400-e237-11e5-bef5-0002a5d5c51b', 0);
+-- Task Two Calculate Fields
+UPDATE FoE_SxBuildings SET 
+  -- SxCF_AA_Rate_BB = ((SxSupplyYieldFifteenMinutes_BB*1.0) / 3.0)
+  SxCF_AA_Rate_BB = ((((SxSupplyYieldFifteenMinutes_BB*1.0) / 3.0) / (SxSupplyYieldFiveMinutes_AA*1.0))*100.0)
+, SxCF_AA_Rate_CC = ((((SxSupplyYieldOneHour_CC*1.0) / 12.0) / (SxSupplyYieldFiveMinutes_AA*1.0))*100.0)
+, SxCF_AA_Rate_DD = ((((SxSupplyYieldFourHours_DD*1.0) / 48.0) / (SxSupplyYieldFiveMinutes_AA*1.0))*100.0)
+, SxCF_AA_Rate_EE = ((((SxSupplyYieldEightHours_EE*1.0) / 96.0) / (SxSupplyYieldFiveMinutes_AA*1.0))*100.0)
+, SxCF_AA_Rate_FF = ((((SxSupplyYieldOneDay_FF*1.0) / 288.0) / (SxSupplyYieldFiveMinutes_AA*1.0))*100.0)
+, SxCF_AA_Rate_GG = ((((SxSupplyYieldTwoDays_GG*1.0) / 576.0) / (SxSupplyYieldFiveMinutes_AA*1.0))*100.0)
+, SxCF_AA_Per_Pop = (SxSupplyYieldFiveMinutes_AA*1.0) / (SxPopRequired*1.0)
+, SxCF_AA_Per_SQR = ((SxSupplyYieldFiveMinutes_AA*1.0) / ((SxSWPixels*1.0)*(SxNWPixels*1.0)))
+WHERE aaPK = NEW.aaPK; END;
+-- END of creating the AFTER INSERT trigger
+--
+-- Creating the AFTER UPDATE Trigger
+CREATE TRIGGER "tgUPDATE-AFTER_FoE_SxBuildings" AFTER UPDATE ON FoE_SxBuildings FOR EACH ROW BEGIN INSERT INTO FoE_aaAuditor (aaToken, aaTable, aaROWID, aaSQLText, aaUUID, dbStatusID)
+VALUES ('UPDATE', 'FoE_SxBuildings', OLD.aaPK,
+'PREW-SxID: ' || OLD.SxID ||
+'~PREW-SxName: ' || OLD.SxName ||
+'~PREW-SxAge: ' || OLD.SxAge ||
+'~PREW-SxTech: ' || OLD.SxTech ||
+'~PREW-SxPopRequired: ' || OLD.SxPopRequired ||
+'~PREW-SxSupplyYieldFiveMinutes_AA: ' || OLD.SxSupplyYieldFiveMinutes_AA ||
+'~PREW-SxSupplyYieldFifteenMinutes_BB: ' || OLD.SxSupplyYieldFifteenMinutes_BB ||
+'~PREW-SxSupplyYieldOneHour_CC: ' || OLD.SxSupplyYieldOneHour_CC ||
+'~PREW-SxSupplyYieldFourHours_DD: ' || OLD.SxSupplyYieldFourHours_DD ||
+'~PREW-SxSupplyYieldEightHours_EE: ' || OLD.SxSupplyYieldEightHours_EE ||
+'~PREW-SxSupplyYieldOneDay_FF: ' || OLD.SxSupplyYieldOneDay_FF ||
+'~PREW-SxSupplyYieldTwoDays_GG: ' || OLD.SxSupplyYieldTwoDays_GG ||
+'~PREW-SxSWPixels: ' || OLD.SxSWPixels ||
+'~PREW-SxNWPixels: ' || OLD.SxNWPixels ||
+'~PREW-SxRoadWidth: ' || OLD.SxRoadWidth ||
+'~PREW-SxBuildTime: ' || OLD.SxBuildTime ||
+'~PREW-SxBuildDiamonds: ' || OLD.SxBuildDiamonds ||
+'~PREW-SxBuildCoins: ' || OLD.SxBuildCoins ||
+'~PREW-SxBuildSupplies: ' || OLD.SxBuildSupplies ||
+'~PREW-SxSellCoins: ' || OLD.SxSellCoins ||
+'~PREW-SxSellSupplies: ' || OLD.SxSellSupplies ||
+'~PREW-SxCF_AA_Rate_BB: ' || OLD.SxCF_AA_Rate_BB ||
+'~PREW-SxCF_AA_Rate_CC: ' || OLD.SxCF_AA_Rate_CC ||
+'~PREW-SxCF_AA_Rate_DD: ' || OLD.SxCF_AA_Rate_DD ||
+'~PREW-SxCF_AA_Rate_EE: ' || OLD.SxCF_AA_Rate_EE ||
+'~PREW-SxCF_AA_Rate_FF: ' || OLD.SxCF_AA_Rate_FF ||
+'~PREW-SxCF_AA_Rate_GG: ' || OLD.SxCF_AA_Rate_GG ||
+'~PREW-SxCF_AA_Per_Pop: ' || OLD.SxCF_AA_Per_Pop ||
+'~PREW-SxCF_AA_Per_SQR: ' || OLD.SxCF_AA_Per_SQR ||
+'~PREW-dbStatusID: ' || OLD.dbStatusID ||
+'~PREW-aaTimeStamp: ' || OLD.aaTimeStamp, 
+'96d6b400-e237-11e5-bef5-0002a5d5c51b', 0); END;
+-- END of creating the AFTER UPDATE trigger
+--
+-- Documenting the database 
+INSERT INTO FoE_ddSelfDoc (ddToken, ddText, dbStatusID) VALUES ('tgINSERT-AFTER_FoE_SxBuildings','Trigger in the FoE_SxBuildings table, records new record insertions', 0);
+INSERT INTO FoE_ddSelfDoc (ddToken, ddText, dbStatusID) VALUES ('tgUPDATE-AFTER_FoE_SxBuildings','Trigger in the FoE_SxBuildings table, records updates', 0);
+INSERT INTO FoE_ddSelfDoc (ddToken, ddText, dbStatusID) VALUES ('FoE_SxBuildings','Data table, holding game information about supply buildings', 0);
+INSERT INTO FoE_ddSelfDoc (ddToken, ddText, dbStatusID) VALUES ('SxID','Manually generated. The table has auto primary key, so if this is not needed then ignore', 0);
+INSERT INTO FoE_ddSelfDoc (ddToken, ddText, dbStatusID) VALUES ('SxName','The name of the building as it appears in the game interface', 0);
+INSERT INTO FoE_ddSelfDoc (ddToken, ddText, dbStatusID) VALUES ('SxAge','The age where the building first becomes available', 0);
+INSERT INTO FoE_ddSelfDoc (ddToken, ddText, dbStatusID) VALUES ('SxTech','The name of the Technology which unlocks th building', 0);
+INSERT INTO FoE_ddSelfDoc (ddToken, ddText, dbStatusID) VALUES ('SxPopRequired','Population count, assumes not up-gradable building', 0);
+INSERT INTO FoE_ddSelfDoc (ddToken, ddText, dbStatusID) VALUES ('SxSupplyYieldFiveMinutes_AA','The amount supply the building generates in 5-minutes cycle', 0);
+INSERT INTO FoE_ddSelfDoc (ddToken, ddText, dbStatusID) VALUES ('SxSupplyYieldFifteenMinutes_BB','The amount supply the building generates in 15-minutes cycle', 0);
+INSERT INTO FoE_ddSelfDoc (ddToken, ddText, dbStatusID) VALUES ('SxSupplyYieldOneHour_CC','The amount supply the building generates in 1-hour cycle', 0);
+INSERT INTO FoE_ddSelfDoc (ddToken, ddText, dbStatusID) VALUES ('SxSupplyYieldFourHours_DD','The amount supply the building generates in 4-hours cycle', 0);
+INSERT INTO FoE_ddSelfDoc (ddToken, ddText, dbStatusID) VALUES ('SxSupplyYieldEightHours_EE','The amount supply the building generates in 8-hours cycle', 0);
+INSERT INTO FoE_ddSelfDoc (ddToken, ddText, dbStatusID) VALUES ('SxSupplyYieldOneDay_FF','The amount supply the building generates in 1-day cycle', 0);
+INSERT INTO FoE_ddSelfDoc (ddToken, ddText, dbStatusID) VALUES ('SxSupplyYieldTwoDays_GG','The amount supply the building generates in 2-days cycle', 0);
+INSERT INTO FoE_ddSelfDoc (ddToken, ddText, dbStatusID) VALUES ('SxSWPixels','Size alongside the SW-NE edge', 0);
+INSERT INTO FoE_ddSelfDoc (ddToken, ddText, dbStatusID) VALUES ('SxNWPixels','Size alongside the NW-SE edge', 0);
+INSERT INTO FoE_ddSelfDoc (ddToken, ddText, dbStatusID) VALUES ('SxRoadWidth','The width of road required in pixels - 0 when none required', 0);
+INSERT INTO FoE_ddSelfDoc (ddToken, ddText, dbStatusID) VALUES ('SxBuildTime','The number of seconds it takes to build', 0);
+INSERT INTO FoE_ddSelfDoc (ddToken, ddText, dbStatusID) VALUES ('SxBuildDiamonds','The building cost in Diamonds', 0);
+INSERT INTO FoE_ddSelfDoc (ddToken, ddText, dbStatusID) VALUES ('SxBuildCoins','The coin part of the building cost', 0);
+INSERT INTO FoE_ddSelfDoc (ddToken, ddText, dbStatusID) VALUES ('SxBuildSupplies','The supply part of the building cost', 0);
+INSERT INTO FoE_ddSelfDoc (ddToken, ddText, dbStatusID) VALUES ('SxSellCoins','Coins recovered by selling this house, set to -1 when not yet recorded', 0);
+INSERT INTO FoE_ddSelfDoc (ddToken, ddText, dbStatusID) VALUES ('SxSellSupplies','Supplies recovered by selling this house, set to -1 when not yet recorded', 0);
+INSERT INTO FoE_ddSelfDoc (ddToken, ddText, dbStatusID) VALUES ('SxCF_AA_Rate_BB','Calculated Field (CF) as SxCF_AA_Rate_BB = ((((SxSupplyYieldFifteenMinutes_BB*1.0) / 3.0) / (SxSupplyYieldFiveMinutes_AA*1.0))*100.0)', 0);
+INSERT INTO FoE_ddSelfDoc (ddToken, ddText, dbStatusID) VALUES ('SxCF_AA_Rate_CC','Calculated Field (CF) as SxCF_AA_Rate_CC = ((((SxSupplyYieldOneHour_CC*1.0) / 12.0) / (SxSupplyYieldFiveMinutes_AA*1.0))*100.0)', 0);
+INSERT INTO FoE_ddSelfDoc (ddToken, ddText, dbStatusID) VALUES ('SxCF_AA_Rate_DD','Calculated Field (CF) as SxCF_AA_Rate_DD = ((((SxSupplyYieldFourHours_DD*1.0) / 48.0) / (SxSupplyYieldFiveMinutes_AA*1.0))*100.0)', 0);
+INSERT INTO FoE_ddSelfDoc (ddToken, ddText, dbStatusID) VALUES ('SxCF_AA_Rate_EE','Calculated Field (CF) as SxCF_AA_Rate_EE = ((((SxSupplyYieldEightHours_EE*1.0) / 96.0) / (SxSupplyYieldFiveMinutes_AA*1.0))*100.0)', 0);
+INSERT INTO FoE_ddSelfDoc (ddToken, ddText, dbStatusID) VALUES ('SxCF_AA_Rate_FF','Calculated Field (CF) as SxCF_AA_Rate_FF = ((((SxSupplyYieldOneDay_FF*1.0) / 288.0) / (SxSupplyYieldFiveMinutes_AA*1.0))*100.0)', 0);
+INSERT INTO FoE_ddSelfDoc (ddToken, ddText, dbStatusID) VALUES ('SxCF_AA_Rate_GG','Calculated Field (CF) as SxCF_AA_Rate_GG = ((((SxSupplyYieldTwoDays_GG*1.0) / 576.0) / (SxSupplyYieldFiveMinutes_AA*1.0))*100.0)', 0);
+INSERT INTO FoE_ddSelfDoc (ddToken, ddText, dbStatusID) VALUES ('SxCF_AA_Per_Pop','Calculated Field (CF) as SxCF_AA_Per_Pop = (SxSupplyYieldFiveMinutes_AA*1.0) / (SxPopRequired*1.0)', 0);
+INSERT INTO FoE_ddSelfDoc (ddToken, ddText, dbStatusID) VALUES ('SxCF_AA_Per_SQR','Calculated Field (CF) as SxCF_AA_Per_Pop = ((SxSupplyYieldFiveMinutes_AA*1.0) / ((SxSWPixels*1.0)*(SxNWPixels*1.0)))', 0);
+-- END of documenting the database


### PR DESCRIPTION
Based on the description of the CxBuildings table...
This is the first version of the supply-generating buildings. At this
point it is not yet decided if Special or Great Buildings should be
added here, in their own table, or both.

The table also includes calculated fields - currently unverified just
how accurate or useful they are.

After running the new script and creating the FoE_SxBuildings table
sqlite responds with the message "Rows affected: 65"
After running the ENTIRE script the response is "Rows affected: 157"